### PR TITLE
Add dotfiles management system based on yaml config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,80 @@
 # DotFiles Manager - DFM
+
+`dfm` allows to manage your tools dotfiles.
+
+## Features
+
+- all settings are in a declarative yaml file
+- setting symlinks targeting your tools dotfiles
+- exporting environment variables for tools that can be managed with
+- executing commands (like script that adds tool autocompletion)
+
+## Usage
+
+To use `dfm`, create your yaml configuration file and execute `dfm.sh` script.
+To create your `dfm` config, you can get the sample `dfm_config.sample.yml` that contains some examples, rename it and change it.
+As `dfm` is only executed once per session, you can add it in you `.bashrc`-like file. If you add a new tool in `dfm` configuration, you simply call it with `DFM_FORCE=1` to update your dotfiles.
+
+Simple call examples:
+```console
+./dfm.sh
+DFM_FORCE=1 ./dfm.sh
+```
+
+You can override `dfm` default environment variables values to setup `dfm`:
+- `DFM_DEBUG`: to activate tracing
+- `DFM_CONFIG_FILE_PATH`: to setup `dfm` config file path
+- `DFM_FORCE`: by defaut, `dfm` is executed once per session, you can force execution with it
+- `DFM_SEMAPHORE`: file path used to know if `dfm` has already been executed
+- `DFM_TEMPDIR`: temporary directory used during `dfm` execution
+- `DFM_VERBOSE`: to display verbose messages during `dfm` execution
+
+More call examples:
+```console
+DFM_VERBOSE=1 ./dfm.sh
+DFM_CONFIG_FILE_PATH=<path_to>/dfm_config.yml ./dfm.sh
+DFM_FORCE=1 DFM_CONFIG_FILE_PATH=<path_to>/dfm_config.yml ./dfm.sh
+DFM_FORCE=1 DFM_VERBOSE=1 DFM_CONFIG_FILE_PATH=<path_to>/dfm_config.yml ./dfm.sh
+```
+
+## Motivation
+
+Some friends are using [`stow`](https://www.gnu.org/software/stow/manual/stow.html) but you can't manage tool's env vars or autocompletion, so I didn't choose this tool.
+I manage all dotfiles by adding this kind of code in my `.bashrc`:
+```console
+# atuin
+if command -v atuin &>/dev/null; then
+  export ATUIN_NOBIND="true"
+  if [[ -f ${MY_DOTCONF_PATH}/atuin.toml ]]; then
+    if [[ ! -L ${HOME}/.config/atuin/config.toml || ! -e ${HOME}/.config/atuin/config.toml ]]; then
+      mkdir -p ${HOME}/.config/atuin
+      ln -sf ${MY_DOTCONF_PATH}/atuin.toml ${HOME}/.config/atuin/config.toml
+    fi
+  fi
+  eval "$(atuin init bash)"
+fi
+
+# awscli
+if command -v aws &>/dev/null; then
+  if [[ -f ${MY_DOTCONF_PATH}/aws ]]; then
+    if [[ ! -L ${HOME}/.aws/config || ! -e ${HOME}/.aws/config ]]; then
+      mkdir -p ${HOME}/.aws
+      ln -sf ${MY_DOTCONF_PATH}/aws ${HOME}/.aws/config
+    fi
+  fi
+fi
+
+# kubectl
+if command -v kubectl &>/dev/null; then
+  source <(kubectl completion bash)
+fi
+
+# vi
+if [[ -f ${MY_DOTCONF_PATH}/.vimrc ]]; then
+  if [[ ! -L ${HOME}/.vimrc || ! -e ${HOME}/.vimrc ]]; then
+    ln -sf ${MY_DOTCONF_PATH}/.vimrc ${HOME}/.vimrc
+  fi
+fi
+```
+
+So to avoid to near always write same code for each tools to manage dotfile, to generate autocompletion and to export some env vars, I created `dfm` to do all this stuff based on a config file.

--- a/dfm.sh
+++ b/dfm.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+#
+# DotFiles Manager - DFM
+# v1.0.0
+#
+# You can override env vars prefixed with 'DFM_'.
+# Only 'yq' extra-tool is mandadory to parse yaml configuration file (see https://github.com/mikefarah/yq).
+#
+
+set -o pipefail
+set -o nounset
+
+# Default env vars values
+DFM_DEBUG=${DFM_DEBUG:=0}
+[[ ${DFM_DEBUG} -eq 1 ]] && set -o xtrace
+DFM_CONFIG_FILE_PATH=${DFM_CONFIG_FILE_PATH:-"~/dfm_config.yml"}
+DFM_FORCE=${DFM_FORCE:=0}
+DFM_SEMAPHORE=${DFM_SEMAPHORE:-"/tmp/dfm.log"}
+DFM_TEMPDIR=${DFM_TEMPDIR:-$(mktemp -d /tmp/dfm.XXXXXXXXX)}
+DFM_VERBOSE=${DFM_VERBOSE:=0}
+
+# allow using DFM_SEMAPHORE in yaml conf file to add logs
+export DFM_SEMAPHORE
+
+trap _dfm_clean INT TERM EXIT
+
+function _dfm_clean() {
+  rm -rf ${DFM_TEMPDIR}
+}
+
+function _dfm_echoVerbose() {
+  if [[ ${DFM_VERBOSE} -eq 1 ]]; then
+    echo -e "$(tput bold)Verbose:$(tput sgr0) ${@}"
+  fi
+}
+
+function _dfm_echoBold() {
+  echo -e "$(tput bold)${@}$(tput sgr0)"
+}
+
+function _dfm_echoYellowBold() {
+  echo -e "$(tput bold)$(tput setaf 3)${@}$(tput sgr0)"
+}
+
+function _dfm_echoSuccess() {
+  echo -e "$(tput bold)$(tput setaf 2)Success:$(tput sgr0) $(tput setaf 2)${@}$(tput sgr0)"
+}
+
+function _dfm_echoError () {
+  echo -e "$(tput bold)$(tput setaf 1)Error:$(tput sgr0) $(tput setaf 1)${@}$(tput sgr0)"
+}
+
+function _dfm_checkTools() {
+  if ! command -v yq &>/dev/null; then
+    _dfm_echoError "The 'yq' tool is required but is not installed. Please go to https://github.com/mikefarah/yq and install it."
+    exit 1
+  fi
+}
+
+function _dfm_checkSemaphore() {
+  if [[ ${DFM_FORCE} -eq 1 ]]; then
+    _dfm_echoVerbose "Force execution, remove semaphore file '${DFM_SEMAPHORE}'."
+    rm -f ${DFM_SEMAPHORE}
+  elif [[ -f ${DFM_SEMAPHORE} ]]; then
+    _dfm_echoVerbose "Semaphore file '${DFM_SEMAPHORE}' exists, no need to continue."
+    _dfm_echoVerbose "To force execution, call with 'DFM_FORCE=1'."
+  fi
+}
+
+function _dfm_createSemaphore() {
+  echo "DFM - Last execution at $(date)" >> ${DFM_SEMAPHORE}
+  echo
+  _dfm_echoVerbose "Semaphore file '${DFM_SEMAPHORE}' created."
+  _dfm_echoVerbose "To force execution, call with 'DFM_FORCE=1'."
+}
+
+function _dfm_check() {
+  # mandatory env var
+  if [[ -z ${DFM_CONFIG_FILE_PATH} ]]; then
+    _dfm_echoError "The env var 'DFM_CONFIG_FILE_PATH' is required but not defined! Please read the documentation."
+    exit 1
+  fi
+
+  # check config file
+  if [[ ! -f ${DFM_CONFIG_FILE_PATH} ]]; then
+    _dfm_echoError "The file '${DFM_CONFIG_FILE_PATH}' doesn't exist! Please read the documentation."
+    exit 1
+  fi
+
+  # check config file parsing
+  if ! yq ${DFM_CONFIG_FILE_PATH} &>/dev/null; then
+    _dfm_echoError "The config file '${DFM_CONFIG_FILE_PATH}' isn't parsable:"
+    yq ${DFM_CONFIG_FILE_PATH}
+    exit 2
+  fi
+}
+
+function _dfm_main() {
+  local _nb_dotfiles=$(yq '.dotfiles | length' ${DFM_CONFIG_FILE_PATH})
+  local _i=0
+  while [[ ${_i} -lt ${_nb_dotfiles} ]]; do
+    local _name=$(yq ".dotfiles[${_i}].name" ${DFM_CONFIG_FILE_PATH})
+    local _conf_target=$(yq ".dotfiles[${_i}].conf_target | envsubst" ${DFM_CONFIG_FILE_PATH})
+    local _conf_symlink=$(yq ".dotfiles[${_i}].conf_symlink | envsubst" ${DFM_CONFIG_FILE_PATH})
+    local _binary=$(yq ".dotfiles[${_i}].binary" ${DFM_CONFIG_FILE_PATH})
+
+    _dfm_echoYellowBold "\nManaging '${_name}'..."
+
+    # check activation
+    _dfm_echoVerbose "Configuration symlink: ${_conf_symlink}"
+    if [[ $(yq ".dotfiles[${_i}].enabled" ${DFM_CONFIG_FILE_PATH}) == "false" ]]; then
+      rm -f ${_conf_symlink}
+      _dfm_echoBold "Not managing '${_name}': this dotfile is disabled. The symlink is removed if existed."
+      ((_i++))
+      continue
+    fi
+
+    # check binary
+    if ! command -v ${_binary} &>/dev/null; then
+      _dfm_echoBold "Not managing '${_name}': binary ${_binary} doesn't exist."
+      ((_i++))
+      continue
+    fi
+
+    # create configuration symlink
+    _dfm_echoVerbose "Configuration target: ${_conf_target}"
+    if [[ ! -f ${_conf_target} ]]; then
+      _dfm_echoBold "The configuration target file '${_conf_target}' doens't exist."
+    else
+      if [[ ! -L ${_conf_symlink} ||  ! -e ${_conf_symlink} ]]; then
+        mkdir -p $(dirname ${_conf_symlink})
+        ln -sf ${_conf_target} ${_conf_symlink}
+      fi
+      ls -lh ${_conf_symlink}
+    fi
+
+    # export env vars if needed
+    if [[ $(yq ".dotfiles[${_i}].export_vars | length" ${DFM_CONFIG_FILE_PATH}) -gt 0 ]]; then
+      local _nb_elts=$(yq ".dotfiles[${_i}].export_vars | length" ${DFM_CONFIG_FILE_PATH})
+      local _e=0
+      while [[ ${_e} -lt ${_nb_elts} ]]; do
+        local _var_name=$(yq ".dotfiles[${_i}].export_vars[${_e}].name" ${DFM_CONFIG_FILE_PATH})
+        local _var_value=$(yq ".dotfiles[${_i}].export_vars[${_e}].value" ${DFM_CONFIG_FILE_PATH})
+        export ${_var_name}="${_var_value}"
+        _dfm_echoVerbose "Exporting '${_var_name}=${_var_value}'"
+        ((_e++))
+      done
+    fi
+
+    # execute init command if needed
+    if [[ $(yq ".dotfiles[${_i}].init_command | length" ${DFM_CONFIG_FILE_PATH}) -gt 0 ]]; then
+      local _init_command=$(yq ".dotfiles[${_i}].init_command | envsubst" ${DFM_CONFIG_FILE_PATH})
+      _dfm_echoVerbose "init_command: ${_init_command}"
+      local _dotconf_tempfile="${DFM_TEMPDIR}/${_binary}"
+      _dfm_echoVerbose "_dotconf_tempfile: ${_dotconf_tempfile}"
+      echo "${_init_command}" > ${_dotconf_tempfile}
+      _dfm_echoVerbose "execute this command:\n\t$(cat ${_dotconf_tempfile})"
+      eval "$(cat ${_dotconf_tempfile})" &>/dev/null
+    fi
+
+    _dfm_echoSuccess "Managing '${_name}' is done."
+    ((_i++))
+  done
+}
+
+###### main #####
+
+_dfm_checkTools
+_dfm_checkSemaphore
+if [[ ! -f ${DFM_SEMAPHORE} ]]; then
+  _dfm_check
+  _dfm_main
+  _dfm_createSemaphore
+fi

--- a/dfm_config.sample.yml
+++ b/dfm_config.sample.yml
@@ -1,0 +1,51 @@
+---
+author: Your name here if you want
+version: 0.0.0
+
+dotfiles:
+
+  - name: my_bin
+    comment: Example to explain yaml configuration
+    binary: my_bin
+    enabled: false # set 'true' to enable my_bin setup
+    conf_target: ${YOUR_REPO_PATH}/config/my_bin.toml # you can use your env vars, set "" if not needed
+    conf_symlink: ${HOME}/.config/my_bin/config.toml # you can use your env vars, set "" if not needed
+    export_vars:
+      - name: MY_BIN_VAR_NAME_ONE
+        value: value_one
+      - name: MY_BIN_VAR_NAME_TWO
+        value: value_two
+    init_command: my_bin completion bash; echo "my_bin - $(date)" >> ${DFM_SEMAPHORE}
+
+  - name: atuin - https://github.com/atuinsh/atuin
+    comment: Full real example
+    binary: atuin
+    enabled: true
+    conf_target: ${YOUR_CONFIG_DIR}/atuin.toml
+    conf_symlink: ${HOME}/.config/atuin/config.toml
+    export_vars:
+      - name: ATUIN_NOBIND
+        value: "false"
+    init_command: atuin init bash; echo "atuin - $(date)" >> ${DFM_SEMAPHORE}
+
+  - name: awscli2
+    comment: Disabled example with only configuration file to target, without 'init_command' and without exporting env var
+    binary: aws
+    enabled: false
+    conf_target: ${YOUR_CONFIG_DIR}/aws
+    conf_symlink: ${HOME}/.aws/config
+
+  - name: bidon
+    comment: Example of a not existing binary
+    binary: bidon
+    enabled: true
+    conf_target: ${YOUR_CONFIG_DIR}/bidon
+    conf_symlink: ${HOME}/.bidon/config
+
+  - name: dasel - https://github.com/TomWright/dasel
+    comment: Example with only 'init_command', without configuration file to target and without exporting env var
+    binary: dasel
+    enabled: false
+    conf_target: ""
+    conf_symlink: ""
+    init_command: dasel completion bash


### PR DESCRIPTION
Introduce a dotfiles manager based on yaml configuration.

Call examples:
```
<path_to>/dfm.sh
DFM_CONFIG_FILE_PATH=<path_to>/dfm_config.yml <path_to>/dfm.sh
DFM_VERBOSE=1 <path_to>/dfm.sh
DFM_FORCE=1 <path_to>/dfm.sh
DFM_FORCE=1 DFM_VERBOSE=1 DFM_CONFIG_FILE_PATH=<path_to>/dfm_config.yml <path_to>/dfm.sh
DFM_FORCE=1 DFM_CONFIG_FILE_PATH=<path_to>/dfm_config.yml <path_to>/dfm.sh
```